### PR TITLE
migration and model change to not allow null in review column, needed…

### DIFF
--- a/backend/db/migrations/04-create-review.js
+++ b/backend/db/migrations/04-create-review.js
@@ -32,6 +32,7 @@ module.exports = {
           references: { model: "Users", key: "id" },
         },
         review: {
+          allowNull: false,
           type: Sequelize.STRING,
         },
         stars: {

--- a/backend/db/models/review.js
+++ b/backend/db/models/review.js
@@ -24,7 +24,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.INTEGER,
       },
-      review: DataTypes.STRING,
+      review: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
       stars: {
         type: DataTypes.INTEGER,
         // add a custom validator allowing stars to be from 1 to 5 only


### PR DESCRIPTION
… to change schema value on Render again otherwise it won't rerun the migrations, modified put to not need the userId in the body (fixed same way as post request earlier, need to verify the endpoint still works), also got the :spotId/reviews endpoint working, needed just one extra block of code to verify that the review didn't already exist from the logged in user on that specific spot, used a findOne and a where property